### PR TITLE
feat: Tasks emoji shorthands start & scheduled

### DIFF
--- a/docs/docs/data-annotation.md
+++ b/docs/docs/data-annotation.md
@@ -124,7 +124,7 @@ with:
 Note that, if you do not like emojis, you can still annotate these fields textually (`[due:: ]`, `[created:: ]`,
 `[completion:: ]`, `[start:: ]`, `[scheduled:: ]`).
 
-### Task Implicit Fields
+### Implicit Fields
 
 As with pages, Dataview adds a number of implicit fields to each task:
 

--- a/docs/docs/data-annotation.md
+++ b/docs/docs/data-annotation.md
@@ -59,7 +59,7 @@ reviewed: false
 [mood:: okay] | [length:: 2 hours]
 ```
 
-#### Implicit Fields
+### Implicit Fields
 
 Dataview automatically adds a large amount of metadata to each page:
 
@@ -103,7 +103,7 @@ You can also annotate your *tasks* (I.e., lines of the form `- [ ] blah blah bla
 - [X] I finished this on [completion::2021-08-15].
 ```
 
-#### Field Shorthands
+### Field Shorthands
 
 For supporting "common use cases", Dataview understands a few shorthands for common data you may want to annotate task
 with:
@@ -112,15 +112,19 @@ with:
     - Due Date: `🗓️YYYY-MM-DD`
     - Completed Date: `✅YYYY-MM-DD`
     - Created Date: `➕YYYY-MM-DD`
+    - Start Date: `🛫YYYY-MM-DD`
+    - Scheduled Date: `⏳YYYY-MM-DD`
 === "Example"
     - [ ] Do this saturday 🗓️2021-08-29.
     - [x] Completed last saturday ✅2021-08-22.
     - [ ] I made this on ➕1990-06-14.
+    - [ ] Task I can start this weekend 🛫2021-08-29.
+    - [x] Task I finished ahead of schedule ⏳2021-08-29 ✅2021-08-22.
 
 Note that, if you do not like emojis, you can still annotate these fields textually (`[due:: ]`, `[created:: ]`,
-`[completion:: ]`).
+`[completion:: ]`, `[start:: ]`, `[scheduled:: ]`).
 
-#### Implicit Fields
+### Task Implicit Fields
 
 As with pages, Dataview adds a number of implicit fields to each task:
 
@@ -147,6 +151,8 @@ As with pages, Dataview adds a number of implicit fields to each task:
 - `completion`: The date a task was completed; set by `[completion:: ...]` or shorthand syntax.
 - `due`: The date a task is due, if it has one. Set by `[due:: ...]` or shorthand syntax.
 - `created`: The date a task was created; set by `[created:: ...]` or shorthand syntax.
+- `start`: The date a task can be started; set by `[start:: ...]` or shorthand syntax.
+- `scheduled`: The date a task is scheduled to work on; set by `[scheduled:: ...]` or shorthand syntax.
 - `annotated`: True if the task has any custom annotations, and false otherwise.
 - `parent`: The line number of the task above this task, if present; will be null if this is a root-level task.
 - `blockId`: The block ID of this task / list element, if one has been defined with the `^blockId` syntax; otherwise null.

--- a/src/data-import/inline-field.ts
+++ b/src/data-import/inline-field.ts
@@ -173,9 +173,9 @@ export function extractFullLineField(text: string): InlineField | undefined {
 }
 
 export const CREATED_DATE_REGEX = /\u{2795}\s*(\d{4}-\d{2}-\d{2})/u;
-export const DUE_DATE_REGEX = /(?:\u{1F4C5}|\u{1F4C6}|\u{1F5D3}|\u{FE0F})\s*(\d{4}-\d{2}-\d{2})/u;
+export const DUE_DATE_REGEX = /[\u{1F4C5}\u{1F4C6}\u{1F5D3}\u{FE0F}]\s*(\d{4}-\d{2}-\d{2})/u;
 export const DONE_DATE_REGEX = /\u{2705}\s*(\d{4}-\d{2}-\d{2})/u;
-export const SCHEDULED_DATE_REGEX = /(?:\u{23F3}|\u{231B})\s*(\d{4}-\d{2}-\d{2})/u;
+export const SCHEDULED_DATE_REGEX = /[\u{23F3}\u{231B}]\s*(\d{4}-\d{2}-\d{2})/u;
 export const START_DATE_REGEX = /\u{1F6EB}\s*(\d{4}-\d{2}-\d{2})/u;
 
 /** Parse special completed/due/done task fields which are marked via emoji. */

--- a/src/data-import/inline-field.ts
+++ b/src/data-import/inline-field.ts
@@ -173,45 +173,33 @@ export function extractFullLineField(text: string): InlineField | undefined {
 }
 
 export const CREATED_DATE_REGEX = /\u{2795}\s*(\d{4}-\d{2}-\d{2})/u;
-export const DUE_DATE_REGEX = /[\u{1F4C5}\u{1F4C6}\u{1F5D3}\u{FE0F}]{1,}\s*(\d{4}-\d{2}-\d{2})/u;
+export const DUE_DATE_REGEX = /(?:\u{1F4C5}|\u{1F4C6}|\u{1F5D3}|\u{FE0F})\s*(\d{4}-\d{2}-\d{2})/u;
 export const DONE_DATE_REGEX = /\u{2705}\s*(\d{4}-\d{2}-\d{2})/u;
+export const SCHEDULED_DATE_REGEX = /(?:\u{23F3}|\u{231B})\s*(\d{4}-\d{2}-\d{2})/u;
+export const START_DATE_REGEX = /\u{1F6EB}\s*(\d{4}-\d{2}-\d{2})/u;
 
 /** Parse special completed/due/done task fields which are marked via emoji. */
 function extractSpecialTaskFields(line: string): InlineField[] {
-    let results = [];
+    let results: InlineField[] = [];
 
-    let createdMatch = CREATED_DATE_REGEX.exec(line);
-    if (createdMatch)
-        results.push({
-            key: "created",
-            value: createdMatch[1],
-            start: createdMatch.index,
-            startValue: createdMatch.index + 1,
-            end: createdMatch.index + createdMatch[0].length,
-            wrapping: "emoji-shorthand",
-        });
-
-    let dueMatch = DUE_DATE_REGEX.exec(line);
-    if (dueMatch)
-        results.push({
-            key: "due",
-            value: dueMatch[1],
-            start: dueMatch.index,
-            startValue: dueMatch.index + 1,
-            end: dueMatch.index + dueMatch[0].length,
-            wrapping: "emoji-shorthand",
-        });
-
-    let completedMatch = DONE_DATE_REGEX.exec(line);
-    if (completedMatch)
-        results.push({
-            key: "completion",
-            value: completedMatch[1],
-            start: completedMatch.index,
-            startValue: completedMatch.index + 1,
-            end: completedMatch.index + completedMatch[0].length,
-            wrapping: "emoji-shorthand",
-        });
+    [
+        { shorthandDateRegex: CREATED_DATE_REGEX, shorthandDateKey: "created" },
+        { shorthandDateRegex: START_DATE_REGEX, shorthandDateKey: "start" },
+        { shorthandDateRegex: SCHEDULED_DATE_REGEX, shorthandDateKey: "scheduled" },
+        { shorthandDateRegex: DUE_DATE_REGEX, shorthandDateKey: "due" },
+        { shorthandDateRegex: DONE_DATE_REGEX, shorthandDateKey: "completion" },
+    ].forEach(shorthandRegexAndKey => {
+        const shorthandDateMatch = shorthandRegexAndKey.shorthandDateRegex.exec(line);
+        if (shorthandDateMatch)
+            results.push({
+                key: shorthandRegexAndKey.shorthandDateKey,
+                value: shorthandDateMatch[1],
+                start: shorthandDateMatch.index,
+                startValue: shorthandDateMatch.index + 1,
+                end: shorthandDateMatch.index + shorthandDateMatch[0].length,
+                wrapping: "emoji-shorthand",
+            });
+    });
 
     return results;
 }

--- a/src/data-model/markdown.ts
+++ b/src/data-model/markdown.ts
@@ -237,6 +237,14 @@ export class ListItem {
             this.fields.get("compday"))?.[0];
     }
 
+    public start(): Literal | undefined {
+        return this.fields.get("start")?.[0];
+    }
+
+    public scheduled(): Literal | undefined {
+        return this.fields.get("scheduled")?.[0];
+    }
+
     /** Create an API-friendly copy of this list item. De-duplication is done via the provided cache. */
     public serialize(cache: ListSerializationCache): SListItem {
         // Map children to their serialized/de-duplicated equivalents right away.
@@ -276,11 +284,15 @@ export class ListItem {
 
             let created = this.created(),
                 due = this.due(),
-                completed = this.completed();
+                completed = this.completed(),
+                start = this.start(),
+                scheduled = this.scheduled();
 
             if (created) result.created = Values.deepCopy(created);
             if (due) result.due = Values.deepCopy(due);
             if (completed) result.completion = Values.deepCopy(completed);
+            if (start) result.start = Values.deepCopy(start);
+            if (scheduled) result.scheduled = Values.deepCopy(scheduled);
         }
 
         return result as SListItem;

--- a/src/data-model/serialized/markdown.ts
+++ b/src/data-model/serialized/markdown.ts
@@ -114,4 +114,8 @@ export interface STask extends SListItemBase {
     due?: Literal;
     /** If present, then the time that this task was completed. */
     completion?: Literal;
+    /** If present, then the day that this task can be started. */
+    start?: Literal;
+    /** If present, then the day that work on this task is scheduled. */
+    scheduled?: Literal;
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -475,7 +475,7 @@ class GeneralSettingsTab extends PluginSettingTab {
                     await this.plugin.updateSettings({ taskCompletionText: value.trim() });
                 })
             );
-        
+
         new Setting(this.containerEl)
             .setName("Automatic Task Completion Date Format")
             .setDesc(

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -10,7 +10,7 @@ export interface QuerySettings {
     /** The name of the inline field to be added as a task's completion when checked */
     taskCompletionText: string;
     /** Date format of the task's completion timestamp */
-    taskCompletionDateFormat: string,
+    taskCompletionDateFormat: string;
     /** If true, render a modal which shows no results were returned. */
     warnOnEmptyResult: boolean;
     /** Whether or not automatic view refreshing is enabled. */

--- a/src/test/parse/parse.inline.test.ts
+++ b/src/test/parse/parse.inline.test.ts
@@ -119,6 +119,26 @@ describe("Inline Inline With HTML", () => {
     });
 });
 
+describe("Inline task emoji shorthands", () => {
+    test("Created emoji shorthand", () => {
+        let result = extractInlineFields(" - [ ] testTask \u{2795}2022-07-25", true);
+        expect(result[0].key).toEqual("created");
+        expect(result[0].value).toEqual("2022-07-25");
+    });
+
+    test("Start date emoji shorthand", () => {
+        let result = extractInlineFields(" - [ ] testTask 🛫2022-07-21", true);
+        expect(result[0].key).toEqual("start");
+        expect(result[0].value).toEqual("2022-07-21");
+    });
+
+    test("Scheduled date emoji shorthand", () => {
+        let result = extractInlineFields(" - [ ] testTask ⏳2022-07-24", true);
+        expect(result[0].key).toEqual("scheduled");
+        expect(result[0].value).toEqual("2022-07-24");
+    });
+});
+
 describe("Set Inline", () => {
     test("Add Annotation", () => {
         let input = "- [ ] an uncompleted task";

--- a/src/ui/lp-render.ts
+++ b/src/ui/lp-render.ts
@@ -92,7 +92,7 @@ class InlineWidget extends WidgetType {
      */
     ignoreEvent(event: MouseEvent | Event): boolean {
         // instanceof check does not work in pop-out windows, so check it like this
-        if (event.type === 'mousedown') {
+        if (event.type === "mousedown") {
             const currentPos = this.view.posAtCoords({ x: (event as MouseEvent).x, y: (event as MouseEvent).y });
             if ((event as MouseEvent).shiftKey) {
                 // Set the cursor after the element so that it doesn't select starting from the last cursor position.

--- a/src/ui/views/task-view.tsx
+++ b/src/ui/views/task-view.tsx
@@ -63,7 +63,12 @@ function TaskItem({ item }: { item: STask }) {
 
         let updatedText = undefined;
         if (context.settings.taskCompletionTracking)
-            updatedText = setTaskCompletion(item.text, context.settings.taskCompletionText, context.settings.taskCompletionDateFormat, completed);
+            updatedText = setTaskCompletion(
+                item.text,
+                context.settings.taskCompletionText,
+                context.settings.taskCompletionDateFormat,
+                completed
+            );
 
         rewriteTask(context.app.vault, item, status, updatedText);
     };
@@ -274,11 +279,20 @@ function trimEndingLines(text: string): string {
 }
 
 /** Set the task completion key on check. */
-export function setTaskCompletion(originalText: string, completionKey: string, completionDateFormat: string, complete: boolean): string {
+export function setTaskCompletion(
+    originalText: string,
+    completionKey: string,
+    completionDateFormat: string,
+    complete: boolean
+): string {
     if (!complete) return trimEndingLines(setInlineField(originalText, completionKey, undefined));
 
     let parts = originalText.split(/\r?\n/u);
-    parts[parts.length - 1] = setInlineField(parts[parts.length - 1], completionKey, DateTime.now().toFormat(completionDateFormat));
+    parts[parts.length - 1] = setInlineField(
+        parts[parts.length - 1],
+        completionKey,
+        DateTime.now().toFormat(completionDateFormat)
+    );
     return parts.join("\n");
 }
 


### PR DESCRIPTION
* chore: fix prettier errors in existing sources (main, settings, lp-render, task-view.tsx)
* refactor: Reduce duplicated code in processing of emoji shorthands in tasks
* feat: Add task emoji shorthands for start and scheduled. Fixes #1003. dataview can now parse all the shorthands used by [obsidian-tasks](https://github.com/obsidian-tasks-group/obsidian-tasks)
* tests: Add tests for new (and old) emoji shorthands.
* docs: Document new shorthands on Data Annotation page. Fix a couple of nearby markdownlint errors.